### PR TITLE
Fix the parsing of spin options

### DIFF
--- a/remote-uci/src/engine.rs
+++ b/remote-uci/src/engine.rs
@@ -124,7 +124,8 @@ impl Engine {
                         Some(b"Hash") => match parts.next() {
                             Some(b"type") => {
                                 info.max_hash = parts
-                                    .skip_while(|part| part == b"max")
+                                    .skip_while(|part| part != b"max")
+                                    .skip(1)
                                     .next()
                                     .and_then(|part| btoi::btou(part).ok())
                             }
@@ -133,7 +134,8 @@ impl Engine {
                         Some(b"Threads") => match parts.next() {
                             Some(b"type") => {
                                 info.max_threads = parts
-                                    .skip_while(|part| part == b"max")
+                                    .skip_while(|part| part != b"max")
+                                    .skip(1)
                                     .next()
                                     .and_then(|part| btoi::btou(part).ok())
                             }


### PR DESCRIPTION
This patch fixes the parsing of the Threads and Hash options by skipping all
tokens not matching b"max", and then skipping the token itself before parsing
the max value.