### PR TITLE
Fix expression in script

### DIFF
--- a/stockfish/usr/bin/stockfish
+++ b/stockfish/usr/bin/stockfish
@@ -7,7 +7,7 @@ elif grep -wq avx512f /proc/cpuinfo && grep -wq avx512bw /proc/cpuinfo; then
 elif grep -wq bmi2 /proc/cpuinfo; then
     if grep -wq GenuineIntel /proc/cpuinfo; then
         arch=x86-64-bmi2
-    elif grep -wq AuthenticAMD /proc/cpuinfo && [[ "$(grep --max-count=1 'cpu family' /proc/cpuinfo | sed -e 's/^.*: //')" -ge 25 ]]; then
+    elif grep -wq AuthenticAMD /proc/cpuinfo && expr "$(grep --max-count=1 'cpu family' /proc/cpuinfo | sed -e 's/^.*: //')" ">=" 25 > /dev/null; then
         arch=x86-64-bmi2
     else
         # On AMD, bmi2 is emulated before Zen 3, so that using it is a slowdown


### PR DESCRIPTION
thanks for working on the external engine functionality. I believe this will be a great feature.

Testing the current setup, I found this error message

```
$ ./stockfish quit
./stockfish: 10: [[: not found
Stockfish 15 by the Stockfish developers (see AUTHORS file)
```

which probably is kind of syntax error. I fixed it locally as shown here, tests fine (and finds the right arch).

```
$ ./stockfish quit
Stockfish 15 by the Stockfish developers (see AUTHORS file)
```

I'm not sure this is the cleanest solution, however.