### PR TITLE
Fix `CMD` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ COPY --from=remote-uci /remote-uci_1-1_amd64.deb .
 RUN dpkg -i /remote-uci_*_amd64.deb
 EXPOSE 9670/tcp
 ENV REMOTE_UCI_LOG info
-CMD /usr/bin/remote-uci --bind 0.0.0.0:9670 stockfish
+CMD /usr/bin/remote-uci --bind 0.0.0.0:9670 --engine stockfish


### PR DESCRIPTION
Update the CMD directive to use the --engine flag in the remote-uci command

Fixes https://github.com/lichess-org/external-engine/issues/6