### PR TITLE
Add cli flags for controlling the published url + Docker QoL updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ Installing the official provider
 Provides Stockfish 15 for 64-bit x86 platforms, built with profile-guided
 optimization, automatically selecting the best available binary for your CPU.
 
+### Docker/Docker Compose
+
+#### Docker
+
+```sh
+sh run-docker.sh
+```
+
+#### Docker Compose
+
+```sh
+./deps.sh
+docker-compose up
+```
+
+Then open the "External engine for Lichess" application or visit
+http://localhost:9670/.
+
 ### Ubuntu, Debian
 
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+# docker-compose.yml
+version: '3.5'
+
+services:
+  remote-uci:
+    container_name: remote-uci-engine
+    image: external-engine
+    # Uncomment the line below and add any additional arguments to pass to remote-uci
+    #command: [ "--publish-addr", "stockfish.example.net", "--publish-addr-tls", "--max-threads", "6" ]
+    build: 
+      context: ./
+      args:
+        # For faster builds set this to the number of CPU threads on the system
+        BUILD_THREADS: 2
+    ports:
+      - "127.0.0.1:9670:9670"
+    restart: unless-stopped


### PR DESCRIPTION
## Published URL Changes - Fixes #8 
- Add `--publish-addr <host_address>` flag which allows customizing the host in the registration links `url` query param
- Add `--publish-addr-tls` flag which when passed sets the protocol for the published url to `wss://`

## Docker QoL Updates
- Change `CMD` to `ENTRYPOINT` to facilitate passing in runtime args to remote-uci
- Add a build arg to the Dockerfile to set the number of CPU threads used when building stockfish
- Add docker-compose.yml for convenience
- Update README.md with Docker related instructions