### PR TITLE
Add signal handling to shutdown webserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,11 @@ RUN cd vendor && \
     tar xf sde-external-9.0.0-2021-11-07-lin.tar.xz && \
     tar xf x86_64-linux-musl-native.tgz && \
     mv nn-6877cd24400e.nnue Stockfish/src
+
 ENV SDE_PATH /stockfish/vendor/sde-external-9.0.0-2021-11-07-lin/sde64
 ENV CXX /stockfish/vendor/x86_64-linux-musl-native/bin/x86_64-linux-musl-g++
 ENV STRIP /stockfish/vendor/x86_64-linux-musl-native/bin/strip
+
 ARG BUILD_THREADS=2
 RUN mkdir -p usr/lib/stockfish && \
     cd vendor/Stockfish/src && \
@@ -20,6 +22,7 @@ RUN mkdir -p usr/lib/stockfish && \
         ${STRIP} stockfish-${arch} && \
         cp stockfish-${arch} ../../../usr/lib/stockfish/; \
     done
+
 WORKDIR /stockfish_15-1_amd64
 RUN cp -R /stockfish/DEBIAN /stockfish/usr . && \
     md5sum $(find * -type f -not -path 'DEBIAN/*') > DEBIAN/md5sums && \

--- a/remote-uci/Cargo.toml
+++ b/remote-uci/Cargo.toml
@@ -25,7 +25,7 @@ serde_with = "1.13.0"
 shakmaty = "0.21.2"
 sysinfo = "0.24.5"
 thiserror = "1.0.31"
-tokio = { version = "1.18.0", features = ["rt", "macros", "sync", "process"] }
+tokio = { version = "1.18.0", features = ["rt", "macros", "sync", "process", "signal"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 raw-cpuid = "10.3.0"

--- a/remote-uci/src/main.rs
+++ b/remote-uci/src/main.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use clap::Parser;
 use listenfd::ListenFd;
 use remote_uci::{make_server, Opts};
+use tokio::signal::unix::{signal, SignalKind};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -26,5 +27,5 @@ async fn shutdown_signal() {
     tokio::signal::ctrl_c()
         .await
         .expect("Expect shutdown signal handler");
-    println!("\nRecieved Sigterm, shutting down gracefully...");
+    println!("\nRecieved SIGINT, shutting down gracefully...");
 }

--- a/remote-uci/src/main.rs
+++ b/remote-uci/src/main.rs
@@ -18,6 +18,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let (spec, server) = make_server(Opts::parse(), ListenFd::from_env()).await?;
     println!("{}", spec.registration_url());
-    server.await?;
+    server.with_graceful_shutdown(shutdown_signal()).await?;
     Ok(())
+}
+
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("Expect shutdown signal handler");
+    println!("\nRecieved Sigterm, shutting down gracefully...");
 }

--- a/remote-uci/src/main.rs
+++ b/remote-uci/src/main.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use clap::Parser;
 use listenfd::ListenFd;
 use remote_uci::{make_server, Opts};
-use tokio::signal::unix::{signal, SignalKind};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
Configures the web server to gracefully shutdown when it receives the sigterm signal.