### PR TITLE
Fix #18 by moving pipes to end of line instead of beginning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf

--- a/Deps.ps1
+++ b/Deps.ps1
@@ -2,8 +2,8 @@ git submodule update --init --recursive
 
 Set-Location .\stockfish\vendor
 
-Get-Content downloads.txt
-| Where-Object { -Not (Test-Path $(Split-Path $_ -Leaf)) }
-| ForEach-Object { Invoke-WebRequest $_ -OutFile $(Split-Path $_ -Leaf) }
+Get-Content downloads.txt |
+   Where-Object { -Not (Test-Path $(Split-Path $_ -Leaf)) } |
+   ForEach-Object { Invoke-WebRequest $_ -OutFile $(Split-Path $_ -Leaf) }
 
 Set-Location .\..\..


### PR DESCRIPTION
At first I thought a file was missing from the repo but it turns out to be a powershell syntax error. I fixed it by moving the pipes in Deps.ps1 to the end of the line instead of the beginning.