### PR TITLE
Log 'info ...' lines from the engine

### DIFF
--- a/example-provider.py
+++ b/example-provider.py
@@ -173,10 +173,9 @@ class Engine:
             if not line:
                 continue
 
-            command_and_params = line.split(None, 1)
+            logging.debug("%d >> %s", self.process.pid, line)
 
-            if command_and_params[0] != "info":
-                logging.debug("%d >> %s", self.process.pid, line)
+            command_and_params = line.split(None, 1)
 
             if len(command_and_params) == 1:
                 return command_and_params[0], ""


### PR DESCRIPTION
Since we can now control the log-level from the CLI (as in https://github.com/lichess-org/external-engine/pull/27), I think it would be useful to output the `info ...` lines from the engine again (it looks like this functionality was removed in https://github.com/lichess-org/external-engine/commit/8d931e85e035347dab3f5ae132a9cc8cfe13872c).