### PR TITLE
quick solution to parse arguments from configuration file

### DIFF
--- a/example-provider.py
+++ b/example-provider.py
@@ -277,7 +277,7 @@ class Engine:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__, fromfile_prefix_chars='@')
     parser.add_argument("--name", default="Alpha 2", help="Engine name to register")
     parser.add_argument("--engine", help="Shell command to launch UCI engine", required=True)
     parser.add_argument("--setoption", nargs=2, action="append", default=[], metavar=("NAME", "VALUE"), help="Set a custom UCI option")


### PR DESCRIPTION
I don't want my lichess token in my shell's history file. This way it is also possible to switch between different configurations, quickly.

For now I couldn't come up with a implementation to parse a configuration file without editing much of the code.